### PR TITLE
no Sub::Uplevel

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Changes for Sub::Uplevel
 
 {{$NEXT}}
 
+    - add "no Sub::Uplevel"
+
 0.24      2012-02-20 22:18:46 EST5EDT
 
     - no changes from 0.23_03

--- a/t/99_no_sub_uplevel.t
+++ b/t/99_no_sub_uplevel.t
@@ -1,0 +1,28 @@
+use Test::More;
+use Sub::Uplevel;
+BEGIN {
+	eval 'use Time::HiRes qw(time); 1'
+		or plan skip_all => 'Need Time::HiRes.';
+}
+	
+plan tests => 1;
+
+my @times1 = (time);
+for (0..10_000) {
+	my $x = $_ + (caller)[2];
+}
+push @times1, time;
+
+no Sub::Uplevel;
+
+my @times2 = (time);
+for (0..10_000) {
+	my $x = $_ + (caller)[2];
+}
+push @times2, time;
+
+diag "Timing results...";
+diag sprintf q(Sub::Uplevel's caller: %0.6f sec), $times1[1]-$times1[0];
+diag sprintf q(Built-in caller: %0.6f sec), $times2[1]-$times2[0];
+
+ok(!eval { uplevel 0, sub {}; 1 }, 'uplevel dies now');


### PR DESCRIPTION
This feature restores the built-in caller() function. It needs to be used with care, but can speed up code that uses Sub::Uplevel early on but doesn't need it later.
