### PR TITLE
do not assume . is in @INC

### DIFF
--- a/t/02_uplevel.t
+++ b/t/02_uplevel.t
@@ -130,6 +130,7 @@ $carp_regex =~ s/88/88\.?/; # Perl 5.15 series Carp adds period
 like( $warning, "/$carp_regex/", 'carp() fooled' );
 
 
+use lib '.';
 use t::lib::Foo;
 can_ok( 'main', 'fooble' );
 

--- a/t/08_exporter.t
+++ b/t/08_exporter.t
@@ -11,6 +11,7 @@ plan tests => 1;
 # import() function
 
 package main;
+use lib '.';
 require t::lib::Importer;
 require t::lib::Bar;
 t::lib::Importer::import_for_me('t::lib::Bar','func3');


### PR DESCRIPTION
perl 5.25.7 can be configured with . not in `@INC`.  Explicitly add it for tests that require it.