### PR TITLE
do not assume . is in @INC

### DIFF
--- a/t/02_uplevel.t
+++ b/t/02_uplevel.t
@@ -130,7 +130,8 @@ $carp_regex =~ s/88/88\.?/; # Perl 5.15 series Carp adds period
 like( $warning, "/$carp_regex/", 'carp() fooled' );
 
 
-use t::lib::Foo;
+use lib 't/lib';
+use Foo;
 can_ok( 'main', 'fooble' );
 
 #line 114

--- a/t/08_exporter.t
+++ b/t/08_exporter.t
@@ -11,8 +11,9 @@ plan tests => 1;
 # import() function
 
 package main;
-require t::lib::Importer;
-require t::lib::Bar;
-t::lib::Importer::import_for_me('t::lib::Bar','func3');
+use lib 't/lib';
+require Importer;
+require Bar;
+Importer::import_for_me('Bar','func3');
 can_ok('main','func3');
 

--- a/t/lib/Bar.pm
+++ b/t/lib/Bar.pm
@@ -1,4 +1,4 @@
-package t::lib::Bar;
+package Bar;
 use warnings;
 use strict;
 require Exporter;

--- a/t/lib/Foo.pm
+++ b/t/lib/Foo.pm
@@ -1,4 +1,4 @@
-package t::lib::Foo;
+package Foo;
 
 # Hook::LexWrap does this, Sub::Uplevel appears to interfere.
 sub import { *{caller()."::fooble"} = \&fooble }

--- a/t/lib/Importer.pm
+++ b/t/lib/Importer.pm
@@ -1,4 +1,4 @@
-package t::lib::Importer;
+package Importer;
 use warnings;
 use strict;
 use Sub::Uplevel qw/:aggressive/;


### PR DESCRIPTION
alternative to #6
perl 5.25.7 can be configured with . not in @INC. Explicitly add it for tests that require it.