### PR TITLE
No dot by default in inc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 /pm_to_blib
 /PM_to_blib
 /MYMETA.yml
+/MYMETA.json
 /Sub-Uplevel-*

--- a/t/02_uplevel.t
+++ b/t/02_uplevel.t
@@ -130,6 +130,7 @@ $carp_regex =~ s/88/88\.?/; # Perl 5.15 series Carp adds period
 like( $warning, "/$carp_regex/", 'carp() fooled' );
 
 
+use lib '.';
 use t::lib::Foo;
 can_ok( 'main', 'fooble' );
 

--- a/t/08_exporter.t
+++ b/t/08_exporter.t
@@ -11,6 +11,7 @@ plan tests => 1;
 # import() function
 
 package main;
+use lib '.';
 require t::lib::Importer;
 require t::lib::Bar;
 t::lib::Importer::import_for_me('t::lib::Bar','func3');


### PR DESCRIPTION
Many CPAN libraries are dependent upon Sub::Uplevel and cannot be tested against perl-5.26.0 until Sub::Uplevel is in an installable state.  So I would request that you apply this p.r. (or its equivalent -- there are a variety of ways to include '.' in a test file) and issue a new CPAN release as soon as possible.

Thank you very much.
Jim Keenan